### PR TITLE
Making shell scripts runnable on macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # global for error reporting
 ASDF_MAVEN_ERROR=""

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 get_maven_versions() {
   # super clumsy regex to locate all Maven version tags on their history page


### PR DESCRIPTION
The command /bin/env does not exist on macOS.
Because of that /usr/bin/env is used now.
That exists on macOS and Linux.