### PR TITLE
Fix broken shebang

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # global for error reporting
 ASDF_MAVEN_ERROR=""

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 get_maven_versions() {
   # super clumsy regex to locate all Maven version tags on their history page


### PR DESCRIPTION
## Introduction

As of asdf 0.9.0, these scripts are executed directly and the shebang line matters.  It turns out that `/bin/env` doesn't exist, but `/usr/bin/env` does.  

## How can I be sure?

In `asdf` itself, `bin/asdf` begins with a shebang that uses `/usr/bin/env`.  If we get as far as running the scripts in this plugin, `/usr/bin/env` exists...