### PR TITLE
Detect if `curl` failed and raise error.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -15,8 +15,6 @@ install_maven() {
 }
 
 # Download Maven source from Apache
-#
-# TODO: Capture errors from curl.
 get_maven() {
 	local version=$1
 	local destdir=$2
@@ -26,6 +24,9 @@ get_maven() {
 	local url="$base/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
 
 	curl -fLC - --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$url"
+	if [ ! $? -eq 0 ]; then
+		ASDF_MAVEN_ERROR="Could not download $url. Perhaps the version of Maven you're trying to install does not exist"
+	fi
 }
 
 # Build Maven, copy files and cleanup.
@@ -49,5 +50,8 @@ build_copy_cleanup() {
 #
 install_maven $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
 
-[[ -z "$ASDF_MAVEN_ERROR" ]] || echo "ERROR: $ASDF_MAVEN_ERROR."
-unset ASDF_MAVEN_ERROR
+if [ -n "$ASDF_MAVEN_ERROR" ]; then
+	echo "ERROR: $ASDF_MAVEN_ERROR." > /dev/stderr
+	unset ASDF_MAVEN_ERROR
+	exit 1
+fi


### PR DESCRIPTION
Before this change, you could asdf install some non-existant version of
maven, it would fail, but asdf would be left thinking that maven was
actually installed:

    $ asdf install maven 3.8.5
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
      0   196    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
    curl: (22) The requested URL returned error: 404
    tar (child): 3.8.5.tar.gz: Cannot open: No such file or directory
    tar (child): Error is not recoverable: exiting now
    tar: Child returned status 2
    tar: Error is not recoverable: exiting now
    rm: cannot remove '3.8.5.tar.gz': No such file or directory
    mv: cannot stat 'apache-maven-3.8.5/*': No such file or directory
    rmdir: failed to remove 'apache-maven-3.8.5': No such file or directory

    $ asdf install maven 3.8.5
    maven 3.8.5 is already installed