### PR TITLE
Add support for maven snapshots

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -25,6 +25,10 @@ get_maven() {
 	local base="https://archive.apache.org/dist/maven"
 	local url="$base/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
 
+	if [[ "$version" == *SNAPSHOT ]]; then
+		local url="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.maven&a=apache-maven&v=$version&e=tar.gz&c=bin"
+	fi
+
 	curl -fLC - --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$url"
 }
 

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -8,11 +8,6 @@ get_maven_versions() {
   for line in $(curl -s https://maven.apache.org/docs/history.html); do
     [[ $line =~ $version ]] && echo ${BASH_REMATCH[2]}
   done
-
-  snapshot_version="[0-9].*-SNAPSHOT"
-  for line in $(curl -s https://repository.apache.org/content/repositories/snapshots/org/apache/maven/apache-maven/maven-metadata.xml); do
-    [[ $line =~ $snapshot_version ]] && echo ${BASH_REMATCH[0]}
-  done
 }
 
-get_maven_versions | sort -u | tr "\n" " "
+get_maven_versions | sort -r | head -n 1


### PR DESCRIPTION
Fixes #7

Add support for maven snapshots

latest version is still 3.8.5
```
asdf plugin-test maven https://github.com/mattnelson/asdf-maven.git --asdf-plugin-gitref snapshot
Updating maven to snapshot
From https://github.com/mattnelson/asdf-maven
 * [new branch]      snapshot   -> snapshot
Switched to branch 'snapshot'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 8469k  100 8469k    0     0   570k      0  0:00:14  0:00:14 --:--:-- 1129k
x apache-maven-3.8.5/README.txt
<snipped rest of output>
```

testing that snapshot version can be installed
```
asdf plugin-test maven https://github.com/mattnelson/asdf-maven.git --asdf-tool-version 4.0.0-alpha-1-SNAPSHOT --asdf-plugin-gitref snapshot
Updating maven to snapshot
From https://github.com/mattnelson/asdf-maven
 * [new branch]      snapshot   -> snapshot
Switched to branch 'snapshot'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   239  100   239    0     0    381      0 --:--:-- --:--:-- --:--:--   385
100 8933k  100 8933k    0     0  2662k      0  0:00:03  0:00:03 --:--:-- 4158k
<snipped rest of output>
x apache-maven/lib/maven-embedder-4.0.0-alpha-1-SNAPSHOT.jar
<snipped rest of output>
```