### PR TITLE
Update latest-stable to pull semver-based releases

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 get_maven_versions() {
-  # super clumsy regex to locate all Maven version tags on their history page
-  version=".*<td>(<b>)?([0-9]\.[0-9](\.[0-9])?(-.*)?)(</b>)?</td>.*"
+  # regex to locate all semver based (x.x.x) Maven version tags on their history page
+  # we are explicitly ignoring the alpha, beta, rc, and milestone releases 
+  version=".*<td>(<b>)?([0-9]+\.[0-9]+(\.[0-9]+)?)(</b>)?</td>.*"
 
   # iterate all lines coming back from the Maven release history
   for line in $(curl -s https://maven.apache.org/docs/history.html); do


### PR DESCRIPTION
- only return x.x.x based releases
- account for version numbers with more than one digit (e.g. 2.0.10)

Fixes #9 