### PR TITLE
replace travis with github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-plugin:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        version:
+          - latest # test latest
+          - latest:3.6 # test the latest in an old release "series"
+          - "3.6.3" # test a specific old release
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: mvn --version
+          version: ${{ matrix.version }}
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: c
-script: asdf plugin-test maven https://github.com/skotchpine/asdf-maven.git
-before_script:
-  - git clone https://github.com/asdf-vm/asdf.git
-  - . asdf/asdf.sh
-os:
-  - linux
-  - osx

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -2,5 +2,6 @@
 # if asdf provides java, then let's use that rather the system one (if at all avail)
 if asdf current java > /dev/null 2>&1
 then
-    export JAVA_HOME=$(asdf where java)
+    JAVA_HOME=$(asdf where java)
+    export JAVA_HOME
 fi

--- a/bin/install
+++ b/bin/install
@@ -8,10 +8,10 @@ install_maven() {
 	local version=$1
 	local destdir=$2
 
-	get_maven $version $destdir
+	get_maven "$version" "$destdir"
 	[[ -z "$ASDF_MAVEN_ERROR" ]] || return
 
-	build_copy_cleanup $version $destdir
+	build_copy_cleanup "$version" "$destdir"
 }
 
 # Download Maven source from Apache
@@ -19,7 +19,9 @@ get_maven() {
 	local version=$1
 	local destdir=$2
 
-	local major=$(echo $version | cut -d '.' -f 1)
+
+	local major
+	major=$(echo "$version" | cut -d '.' -f 1)
 	local base="https://archive.apache.org/dist/maven"
 	local url="$base/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
 
@@ -27,8 +29,8 @@ get_maven() {
 		local url="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.maven&a=apache-maven&v=$version&e=tar.gz&c=bin"
 	fi
 
-	curl -fLC - --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$url"
-	if [ ! $? -eq 0 ]; then
+
+	if ! curl -fLC - --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$url"; then
 		ASDF_MAVEN_ERROR="Could not download $url. Perhaps the version of Maven you're trying to install does not exist"
 	fi
 }
@@ -38,21 +40,22 @@ build_copy_cleanup() {
 	local version=$1
 	local destdir=$2
 
-	local origin=$(pwd)
-	cd "$destdir"; {
-		tar xzvf $version.tar.gz
-		rm $version.tar.gz
+	local origin
+	origin=$(pwd)
+	cd "$destdir" || exit; {
+		tar xzvf "$version".tar.gz
+		rm "$version".tar.gz
 
-		mv apache-maven-$version/* .
-		rmdir apache-maven-$version
+		mv apache-maven-"$version"/* .
+		rmdir apache-maven-"$version"
 	}
-	cd $origin
+	cd "$origin" || exit
 }
 
 #
 # MAIN
 #
-install_maven $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_maven "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
 
 if [ -n "$ASDF_MAVEN_ERROR" ]; then
 	echo "ERROR: $ASDF_MAVEN_ERROR." > /dev/stderr

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -2,12 +2,12 @@
 
 get_maven_versions() {
   # regex to locate all semver based (x.x.x) Maven version tags on their history page
-  # we are explicitly ignoring the alpha, beta, rc, and milestone releases 
+  # we are explicitly ignoring the alpha, beta, rc, and milestone releases
   version=".*<td>(<b>)?([0-9]+\.[0-9]+(\.[0-9]+)?)(</b>)?</td>.*"
 
   # iterate all lines coming back from the Maven release history
   for line in $(curl -s https://maven.apache.org/docs/history.html); do
-    [[ $line =~ $version ]] && echo ${BASH_REMATCH[2]}
+    [[ $line =~ $version ]] && echo "${BASH_REMATCH[2]}"
   done
 }
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -6,12 +6,12 @@ get_maven_versions() {
 
   # iterate all lines coming back from the Maven release history
   for line in $(curl -s https://maven.apache.org/docs/history.html); do
-    [[ $line =~ $version ]] && echo ${BASH_REMATCH[2]}
+    [[ $line =~ $version ]] && echo "${BASH_REMATCH[2]}"
   done
 
   snapshot_version="[0-9].*-SNAPSHOT"
   for line in $(curl -s https://repository.apache.org/content/repositories/snapshots/org/apache/maven/apache-maven/maven-metadata.xml); do
-    [[ $line =~ $snapshot_version ]] && echo ${BASH_REMATCH[0]}
+    [[ $line =~ $snapshot_version ]] && echo "${BASH_REMATCH[0]}"
   done
 }
 


### PR DESCRIPTION
Unfortunately, this doesn't fail when the installed version is incorrect ([eg: `latest:3.6` installed `3.8.7`.](https://github.com/cj81499/asdf-maven/actions/runs/3990597013/jobs/6844429602#step:2:133) caused by https://github.com/halcyon/asdf-maven/issues/9#issuecomment-1400667772)