### PR TITLE
Update installation to account for different archive directories between releases and snapshots

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -40,11 +40,8 @@ build_copy_cleanup() {
 
 	local origin=$(pwd)
 	cd "$destdir"; {
-		tar xzvf $version.tar.gz
+		tar xzvf $version.tar.gz --strip 1
 		rm $version.tar.gz
-
-		mv apache-maven-$version/* .
-		rmdir apache-maven-$version
 	}
 	cd $origin
 }


### PR DESCRIPTION
The changes in #8 were incomplete, they did not account for different archive directories between snapshots and releases.

Releases are archived into `apache-maven-$version`
Snapshot are archived into `apache-maven`

Refactored install steps to align with maven's self testing installation process to strip the first directory, which allows this plugin to extract/install releases and snapshots the same way.

https://github.com/apache/maven/blob/master/.github/workflows/maven_build_itself.yml#L59
