### PR TITLE
fix: install failure when install path has space

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -8,10 +8,10 @@ install_maven() {
 	local version=$1
 	local destdir=$2
 
-	get_maven $version $destdir
+	get_maven $version "$destdir"
 	[[ -z "$ASDF_MAVEN_ERROR" ]] || return
 
-	build_copy_cleanup $version $destdir
+	build_copy_cleanup $version "$destdir"
 }
 
 # Download Maven source from Apache
@@ -46,13 +46,13 @@ build_copy_cleanup() {
 		mv apache-maven-$version/* .
 		rmdir apache-maven-$version
 	}
-	cd $origin
+	cd "$origin"
 }
 
 #
 # MAIN
 #
-install_maven $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_maven $ASDF_INSTALL_VERSION "$ASDF_INSTALL_PATH"
 
 if [ -n "$ASDF_MAVEN_ERROR" ]; then
 	echo "ERROR: $ASDF_MAVEN_ERROR." > /dev/stderr


### PR DESCRIPTION
Currently, the installation of maven using asdf fails when the installation direction contains space(s). This PR mitigates the issue by wrapping the asdf provided path variables within double quotes.

**Test Case:**
When `ASDF_INSTALLATION_PATH="/tmp/space path"`, the `install` script tries and fails to download maven tar file into `/tmp/space` instead of `/tmp/space path`.