### PR TITLE
Attempt to download from archive URL if cdn URL fails

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -14,6 +14,12 @@ install_maven() {
 	build_copy_cleanup $version "$destdir"
 }
 
+# Function to compare versions
+version_lt() {
+	# returns 0 (true) if first version is less than second version, otherwise 1 (false)
+	[ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" != "$2" ]
+}
+
 # Download Maven source from Apache
 get_maven() {
 	local version=$1
@@ -21,6 +27,12 @@ get_maven() {
 
 	local major=$(echo $version | cut -d '.' -f 1)
 	local base="http://dlcdn.apache.org/maven"
+
+	# Set base URL conditionally based on version
+	if version_lt "$version" "3.8.8"; then
+		base="https://archive.apache.org/dist/maven"
+	fi
+
 	local url="$base/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
 
 	if [[ "$version" == *SNAPSHOT ]]; then

--- a/bin/install
+++ b/bin/install
@@ -14,10 +14,12 @@ install_maven() {
 	build_copy_cleanup $version "$destdir"
 }
 
-# Function to compare versions
-version_lt() {
-	# returns 0 (true) if first version is less than second version, otherwise 1 (false)
-	[ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" != "$2" ]
+download_file() {
+	local url=$1
+	local dest=$2
+
+	curl -fLC - --retry 3 --retry-delay 3 -o "$dest" "$url"
+	return $?
 }
 
 # Download Maven source from Apache
@@ -25,23 +27,28 @@ get_maven() {
 	local version=$1
 	local destdir=$2
 
-	local major=$(echo $version | cut -d '.' -f 1)
-	local base="http://dlcdn.apache.org/maven"
-
-	# Set base URL conditionally based on version
-	if version_lt "$version" "3.8.8"; then
-		base="https://archive.apache.org/dist/maven"
-	fi
-
-	local url="$base/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
+	local major
+	major=$(echo "$version" | cut -d '.' -f 1)
+	local main_url="http://dlcdn.apache.org/maven/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
+	local archive_url="https://archive.apache.org/dist/maven/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
 
 	if [[ "$version" == *SNAPSHOT ]]; then
-		local url="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.maven&a=apache-maven&v=$version&e=tar.gz&c=bin"
+		local snapshot_url="https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.maven&a=apache-maven&v=$version&e=tar.gz&c=bin"
+		download_file "$snapshot_url" "$destdir/$version.tar.gz"
+		if [ $? -ne 0 ]; then
+			ASDF_MAVEN_ERROR="Could not download SNAPSHOT version $version from $snapshot_url. Perhaps the version of Maven you're trying to install does not exist"
+			return 1
+		fi
+		return 0
 	fi
 
-	curl -fLC - --retry 3 --retry-delay 3 -o "$destdir/$version.tar.gz" "$url"
-	if [ ! $? -eq 0 ]; then
-		ASDF_MAVEN_ERROR="Could not download $url. Perhaps the version of Maven you're trying to install does not exist"
+	# Attempt to download from the main URL
+	if [ "$(download_file "$main_url" "$destdir/$version.tar.gz")" -ne 0 ]; then
+		# If the download fails, attempt to download from the archive URL
+		if [ "$(download_file "$archive_url" "$destdir/$version.tar.gz")" -ne 0 ]; then
+			ASDF_MAVEN_ERROR="Could not download Maven $version from either the main or archive URL. Perhaps the version of Maven you're trying to install does not exist"
+			return 1
+		fi
 	fi
 }
 


### PR DESCRIPTION
After [this](https://github.com/halcyon/asdf-maven/commit/fd431d52f94189ddd85ca1cb34f918b9cfad88d0) change, we noticed that versions of maven less than 3.8.8 don't work and you get the following error:

```
ERROR: Could not download http://dlcdn.apache.org/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz. Perhaps the version of Maven you're trying to install does not exist.
```

After looking at the apache cdn url for maven, you can see the oldest version available is 3.8.8:

![image](https://github.com/user-attachments/assets/c1042f91-6d83-4a2c-94c6-4a9754d88738)

If you try to go to maven version 2 or below, you get the following page:

![image](https://github.com/user-attachments/assets/ab4c0390-c833-4fc8-9bd7-ad5ad08766df)

However, if you go to the archive URL, versions less than 3.8.8 are still available.

This change tries to download maven from the CDN URL first, and if it fails, will fallback to the archive URL.