### PR TITLE
Use https in base url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -20,7 +20,7 @@ get_maven() {
 	local destdir=$2
 
 	local major=$(echo $version | cut -d '.' -f 1)
-	local base="http://dlcdn.apache.org/maven"
+	local base="https://dlcdn.apache.org/maven"
 	local url="$base/maven-$major/$version/binaries/apache-maven-$version-bin.tar.gz"
 
 	if [[ "$version" == *SNAPSHOT ]]; then


### PR DESCRIPTION
The base URL has been recently updated In order to fix #16 , but the protocol was changed from `https` to `http`.
It should keep using the secure version of the URL.