### PR TITLE
fix(bin): #26 fix regexp to list versions with 2 digits number

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -11,4 +11,4 @@ get_maven_versions() {
   done
 }
 
-get_maven_versions | sort -r | head -n 1
+get_maven_versions | sort --version-sort -r | head -n 1

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,7 @@
 
 get_maven_versions() {
   # super clumsy regex to locate all Maven version tags on their history page
-  version=".*<td>(<b>)?([0-9]\.[0-9](\.[0-9])?(-.*)?)(</b>)?</td>.*"
+  version=".*<td>(<b>)?([0-9]+\.[0-9]+(\.[0-9]+)?(-[0-9a-zA-Z-]*)?)(</b>)?</td>.*"
 
   # iterate all lines coming back from the Maven release history
   for line in $(curl -s https://maven.apache.org/docs/history.html); do


### PR DESCRIPTION
Fix regexp to read correctly maven version with more than one digits and fix bold rc versions

fix #26 
